### PR TITLE
build: use uwiger/edown for OTP 18.0 support

### DIFF
--- a/rebar_dev.config
+++ b/rebar_dev.config
@@ -59,7 +59,7 @@
       "master"}},
 
     {edown, ".*",
-         {git, "git://github.com/esl/edown.git", "HEAD"}}
+         {git, "git://github.com/uwiger/edown.git", "HEAD"}}
 
 ]}.
 


### PR DESCRIPTION
minor change, however Ulf's fork no longer generates the TOC I think, you might want to check if this is OK for you.
